### PR TITLE
Hotfix/linter issue

### DIFF
--- a/pyfaaster/__version__.py
+++ b/pyfaaster/__version__.py
@@ -4,4 +4,4 @@
 
 # PYFAASTER
 
-__version__ = '0.2.0'
+__version__ = '0.2.1'

--- a/tox.ini
+++ b/tox.ini
@@ -11,19 +11,14 @@ addopts =
     -vvv
 python_files = test_*.py !check_*.py !legacy_*.py
 test_paths = test
-norecursedirs=.git .tox .cache .py36* vendored *.egg-info node_modules .serverless
+norecursedirs=.git .tox .cache .py36* build *.egg-info node_modules .serverless
                 # ^ NO TRAILING SLASHES ON DIRECTORIES!!
 
-
-# Global linter settings.
-# For the copyright check plugin, note that this places no constraints on the location of the copyright
-# lines in the file.  What we need here is a reminder to add the proper text; the rest can be left to convention.
-# It is also not good at checking things that are not python files, because the regular linter
-# will fail.  Non-python files will need to be checked by hand.
 [flake8]
 ignore = E265,E266,E402,E501
+select = E,W,F,R,D,H,C
 max_line_length = 120
-exclude = .git,.tox,.cache,.py36*,vendored,*.egg-info,node_modules,.serverless,.idea
+exclude = .git,.tox,.cache,.py36*,build,*.egg-info,node_modules,.serverless,.idea
 tee = True
 statistics = True
 copyright_check = True
@@ -32,7 +27,7 @@ copyright_regexp = (?m)# Copyright \(c\) 2016-present, CloudZero, Inc\. All righ
 [pep8]
 ignore = E265,E266,E402,E501
 max_line_length = 120
-exclude = .git,.tox,.cache,.py36*,vendored,*.egg-info,node_modules,.serverless,.idea
+exclude = .git,.tox,.cache,.py36*,build,*.egg-info,node_modules,.serverless,.idea
 
 [tox]
 skipsdist = True

--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,14 @@ addopts =
     -vvv
 python_files = test_*.py !check_*.py !legacy_*.py
 test_paths = test
-norecursedirs=.git .tox .cache .py36* build *.egg-info node_modules .serverless
+norecursedirs=.git .tox .cache .py36* build vendored *.egg-info node_modules .serverless
                 # ^ NO TRAILING SLASHES ON DIRECTORIES!!
 
 [flake8]
 ignore = E265,E266,E402,E501
 select = E,W,F,R,D,H,C
 max_line_length = 120
-exclude = .git,.tox,.cache,.py36*,build,*.egg-info,node_modules,.serverless,.idea
+exclude = .git,.tox,.cache,.py36*,build,vendored,*.egg-info,node_modules,.serverless,.idea
 tee = True
 statistics = True
 copyright_check = True
@@ -27,7 +27,7 @@ copyright_regexp = (?m)# Copyright \(c\) 2016-present, CloudZero, Inc\. All righ
 [pep8]
 ignore = E265,E266,E402,E501
 max_line_length = 120
-exclude = .git,.tox,.cache,.py36*,build,*.egg-info,node_modules,.serverless,.idea
+exclude = .git,.tox,.cache,.py36*,build,vendored,*.egg-info,node_modules,.serverless,.idea
 
 [tox]
 skipsdist = True


### PR DESCRIPTION
Found while developing a new library based on this one.  The tox configuration was no longer running all of the linter rules, specifically the ones we use for copyright checks.  Later versions of flake8 require you to be more explicit about which rules run by default, so added a line to deal with this.