### PR TITLE
CP-4865: Add a new decorator events_publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,6 @@ typings/
 
 # text editor
 *.swp
+
+.vscode
+.python-version

--- a/pyfaaster/aws/handlers_decorators_v2.py
+++ b/pyfaaster/aws/handlers_decorators_v2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
 

--- a/pyfaaster/aws/handlers_decorators_v2.py
+++ b/pyfaaster/aws/handlers_decorators_v2.py
@@ -14,7 +14,6 @@ import pyfaaster.aws.publish as publish
 import pyfaaster.aws.tools as tools
 import pyfaaster.common.utils as utils
 
-
 logger = tools.setup_logging('pyfaaster')
 
 
@@ -356,6 +355,63 @@ def publisher(handler):
         result = handler(event, context, **kwargs)
         conn = publish.conn(kwargs['region'], kwargs['account_id'], kwargs['NAMESPACE'])
         publish.publish(conn, result.get('messages', {}))
+        return result
+
+    return handler_wrapper
+
+
+def event_publisher(handler):
+    """ Decorator that will publish events to SNS Topics (and eventually EventBridge).
+    This decorator looks for a 'events' key in the result of the wrapper decorator.
+    It expects result['events'] to be a dict where key is target (i.e. Topic Name or EventBus)
+    or ARN and value is an array messages to be sent. It will publish each event to its respective target.
+
+    Each must adhere to the followign schema:
+    {
+        'type': str,
+        'detail': dict
+    }
+
+    For example:
+
+    response['events'] = {
+        'target-1': [
+            {
+                'type': 'event-1-type',
+                'details': {}
+            },
+            {
+                'type': 'event-2-type',
+                'details': {}
+            },
+        ],
+        'target-2': [
+            {
+                'type': 'event-3-type',
+                'details': {}
+            },
+            {
+                'type': 'event-4-type',
+                'details': {}
+            },
+        ]
+    }
+
+    Args:
+        handler (func): lambda handler whose result will be checked for messages to publish
+
+    Returns:
+        handler (func): a publishing lambda handler
+    """
+
+    @account_id_aware
+    @namespace_aware
+    @region_aware
+    def handler_wrapper(event, context, **kwargs):
+        result = handler(event, context, **kwargs)
+        # TODO: Add code to check configuration and send via SNS or EventBridge accordingly
+        conn = publish.conn(kwargs['region'], kwargs['account_id'], kwargs['NAMESPACE'])
+        publish.publish_events(conn, result.get('events', {}))
         return result
 
     return handler_wrapper

--- a/pyfaaster/aws/publish.py
+++ b/pyfaaster/aws/publish.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
 

--- a/pyfaaster/aws/publish.py
+++ b/pyfaaster/aws/publish.py
@@ -7,8 +7,66 @@ import simplejson as json
 import datetime as dt
 
 import pyfaaster.aws.tools as tools
+from voluptuous import Schema, ALLOW_EXTRA, All
 
 logger = tools.setup_logging('pyfaaster')
+
+
+def _publish_sns_message(conn, topic, message, **kwargs):
+    logger.debug(f'Publishing {message}')
+
+    topic_arn = topic.format(
+        namespace=conn['namespace']) if 'arn:aws:sns' in topic else conn['topic_arn_prefix'] + topic.format(
+        namespace=conn['namespace'])
+
+    if getattr(message, 'get', None) and not message.get('timestamp'):
+        message['timestamp'] = str(dt.datetime.now(tz=dt.timezone.utc))
+
+    if isinstance(message, str):
+        prepared_message = message
+    else:
+        prepared_message = json.dumps(message, iterable_as_array=True)
+
+    logger.debug(f'Publishing {message} to {topic_arn}')
+
+    conn['sns'].publish(
+        TopicArn=topic_arn,
+        Message=prepared_message,
+        **kwargs
+    )
+
+    return message
+
+
+EVENT = Schema({
+    'type': str,
+    'detail': dict
+}, required=True, extra=ALLOW_EXTRA)
+
+
+_validate_events = Schema({
+    All(): [EVENT]
+})
+
+
+def publish_events(conn, events):
+    _validate_events(events)
+    logger.debug(f'Publishing {events}')
+
+    published_events = []
+    for topic, events_for_topic in events.items():
+        for event in events_for_topic:
+            event = _publish_sns_message(conn, topic, event['detail'],
+                                         Subject=event['type'],
+                                         MessageAttributes={
+                                            'message_type': {
+                                                'DataType': 'String',
+                                                'StringValue': event['type']
+                                            }
+                                        })
+            published_events.append(event)
+
+    return published_events
 
 
 def publish(conn, messages):
@@ -16,24 +74,9 @@ def publish(conn, messages):
 
     published_messages = []
     for topic, message in messages.items():
-        topic_arn = topic.format(
-            namespace=conn['namespace']) if 'arn:aws:sns' in topic else conn['topic_arn_prefix'] + topic.format(
-            namespace=conn['namespace'])
-        message = messages[topic]
-        if getattr(message, 'get', None) and not message.get('timestamp'):
-            message['timestamp'] = str(dt.datetime.now(tz=dt.timezone.utc))
-        logger.debug(f'Publishing {message} to {topic_arn}')
-
-        if isinstance(message, str):
-            prepared_message = message
-        else:
-            prepared_message = json.dumps(message, iterable_as_array=True)
-
-        conn['sns'].publish(
-            TopicArn=topic_arn,
-            Message=prepared_message,
-        )
+        message = _publish_sns_message(conn, topic, messages[topic])
         published_messages.append(message)
+
     return published_messages
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
 
+--extra-index-url https://pypi.cloudzero.com/
 docker>=4.3.1
 flake8>=3.8.3
 flake8-copyright>=0.2.2
@@ -12,4 +13,7 @@ pytest-mock>=3.3.1
 twine>=3.2.0
 setuptools>=50.3.0
 wheel>=0.35.1
+hypothesis>=5.37.4
+cz-common-python>=0.10.2
+freezegun>=1.0.0
 -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 boto3>=1.14.60
 simplejson>=3.17.2
 cachetools>=4.1.1
+voluptuous>=0.12.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,16 @@ doctest_optionflags =
     IGNORE_EXCEPTION_DETAIL
 addopts =
     --doctest-modules
+    --cov pyfaaster
+    --cov-report xml
+    --cov-report html:coverage-reports/html
+    --cov-report term
+    --cov-branch
+    --cov-fail-under=50
+    --ignore=setup.py
+    --doctest-modules
     --showlocals
     -vvv
-    --cov=pyfaaster
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     unit

--- a/tests/aws/common.py
+++ b/tests/aws/common.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
 

--- a/tests/aws/common.py
+++ b/tests/aws/common.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
+# Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
+
+
+class MockContext(dict):
+    def __init__(self, farn, function_name=None):
+        self.invoked_function_arn = farn
+        self.function_name = function_name
+        dict.__init__(self, invoked_function_arn=farn, function_name=function_name)

--- a/tests/aws/test_handlers_decorators_v2.py
+++ b/tests/aws/test_handlers_decorators_v2.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
 from collections import namedtuple

--- a/tests/aws/test_handlers_decorators_v2.py
+++ b/tests/aws/test_handlers_decorators_v2.py
@@ -10,15 +10,9 @@ import simplejson as json
 from pyfaaster.aws.exceptions import HTTPResponseException
 import pyfaaster.aws.handlers_decorators_v2 as decs
 import pyfaaster.common.utils as utils
+from tests.aws.common import MockContext
 
 _CONFIG_BUCKET = 'example_config_bucket'
-
-
-class MockContext(dict):
-    def __init__(self, farn, function_name=None):
-        self.invoked_function_arn = farn
-        self.function_name = function_name
-        dict.__init__(self, invoked_function_arn=farn, function_name=function_name)
 
 
 @pytest.fixture(scope='function')

--- a/tests/aws/test_publish.py
+++ b/tests/aws/test_publish.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
 

--- a/tests/aws/test_publisher_decorators.py
+++ b/tests/aws/test_publisher_decorators.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
 

--- a/tests/aws/test_publisher_decorators.py
+++ b/tests/aws/test_publisher_decorators.py
@@ -1,0 +1,197 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
+# Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
+
+import os
+import pytest
+import simplejson as json
+
+import pyfaaster.aws.handlers_decorators_v2 as decs
+from czc.unittest import Context
+import datetime as dt
+import botocore.session
+import freezegun
+from voluptuous import Invalid
+
+from tests.aws.common import MockContext
+from botocore.stub import Stubber
+import pyfaaster.aws.publish as pub
+
+_CONFIG_BUCKET = 'example_config_bucket'
+
+
+@pytest.fixture(scope='function')
+def context(mocker):
+    region = 'us-east-1'
+    account_id = '123456789012'
+    namespace = 'test-ns'
+    sns = botocore.session.get_session().create_client('sns')
+    conn = pub.conn(region, account_id, namespace, client=sns)
+
+    with Context(mocker, decs, modules_to_mock=['publish.conn']) as context:
+        orig_env = os.environ.copy()
+        os.environ['NAMESPACE'] = 'test-ns'
+        os.environ['CONFIG'] = _CONFIG_BUCKET
+        os.environ['ENCRYPT_KEY_ARN'] = 'arn'
+        context.os = {'environ': os.environ}
+        context.region = region
+        context.account_id = account_id
+        context.lambda_context = MockContext(f'arn:aws:lambda:{context.region}:{context.account_id}')
+        context.sns = sns
+        context.mock_publish_conn.return_value = conn
+        yield context
+
+    mocker.stopall()
+    os.environ = orig_env
+
+
+@pytest.mark.unit
+def test_publisher(context, mocker):
+    namespace = os.environ['NAMESPACE']
+    messages = {
+        f'system-{namespace}-topic-1': 'String Message',
+        f'system-{namespace}-topic-2': {'message': 'string', 'timestamp': 'this feature is stupid'}
+    }
+
+    response = {
+        'ResponseMetadata': {
+            'RequestId': 1234,
+            'HTTPStatusCode': 200,
+        }
+    }
+
+    event = {
+        'message': {
+            'foo': 'bar'
+        }
+    }
+
+    @decs.publisher
+    def test(event, context, **kwargs):
+        return {
+            'messages': messages
+        }
+
+    with Stubber(context.sns) as stubber:
+        for topic, message in messages.items():
+            if isinstance(message, str):
+                stubber.add_response('publish', response, {'TopicArn': f'arn:aws:sns:{context.region}:{context.account_id}:{topic}', 'Message': message})
+            else:
+                stubber.add_response('publish', response,
+                                     {'TopicArn': f'arn:aws:sns:{context.region}:{context.account_id}:{topic}',
+                                      'Message': json.dumps(message, iterable_as_array=True)})
+
+        test(event, context.lambda_context)
+
+
+@pytest.mark.unit
+def test_event_publisher_no_events(context):
+    incoming_event = {
+        'message': {
+            'foo': 'bar'
+        }
+    }
+
+    @decs.event_publisher
+    def test(event, context, **kwargs):
+        return {
+        }
+
+    with Stubber(context.sns):
+        test(incoming_event, context.lambda_context)
+
+
+@freezegun.freeze_time('2020-01-01')
+@pytest.mark.unit
+def test_event_publisher_sns_events(context):
+    namespace = os.environ['NAMESPACE']
+    incoming_event = {
+        'message': {
+            'foo': 'bar'
+        }
+    }
+
+    response = {
+        'ResponseMetadata': {
+            'RequestId': 1234,
+            'HTTPStatusCode': 200,
+        },
+    }
+
+    events = {
+        f'system-{namespace}-topic-1': [
+            {'type': 'first-event', 'detail': {'message': 'this feature is stupid'}},
+            {'type': 'second-event', 'detail': {'timestamp': 'this event is stupid'}},
+        ],
+        f'system-{namespace}-topic-2': [
+            {'type': 'third-event', 'detail': {'timestamp': 'this feature is stupid'}}
+        ]
+    }
+
+    @decs.event_publisher
+    def test(event, context, **kwargs):
+        return {
+            'events': events
+        }
+
+    with Stubber(context.sns) as stubber:
+        for topic, events_for_topic in events.items():
+            for event in events_for_topic:
+                expected_event = {
+                    **event['detail']
+                }
+
+                if 'timestamp' not in expected_event:
+                    expected_event['timestamp'] = str(dt.datetime.now(tz=dt.timezone.utc))
+                stubber.add_response('publish', response, {
+                    'TopicArn': f'arn:aws:sns:{context.region}:{context.account_id}:{topic}',
+                    'Message': json.dumps(expected_event, iterable_as_array=True),
+                    'Subject': event['type'],
+                    'MessageAttributes': {
+                        'message_type': {
+                            'DataType': 'String',
+                            'StringValue': event['type']
+                        }
+                    }
+                })
+
+        test(incoming_event, context.lambda_context)
+
+
+@pytest.mark.parametrize('events', [
+    {
+        'system-test-topic-1': [{}]  # No event data
+    },
+    {
+        'system-test-topic-1': [{'eventName': 'valid-event', 'detail': {'timestamp': 'this feature is stupid'}}, {}]  # One good, one bad
+    },
+    {
+        'system-test-topic-1': [{'eventName': 'valid-event'}]  # No detail
+    },
+    {
+        'system-test-topic-1': [{'detail': {'timestamp': 'this feature is stupid'}}]  # No eventName
+    },
+    {
+        'system-test-topic-1': [{'eventName': {'timestamp': 'this feature is stupid'}, 'detail': {}}]  # Invalid type for eventName
+    },
+    {
+        'system-test-topic-1': [{'eventName': 'test', 'detail': 'this is not the right type'}]  # Invalid type for detail
+    }
+])
+@pytest.mark.unit
+def test_event_publisher_catches_bad_events(context, events):
+    incoming_event = {
+        'message': {
+            'foo': 'bar'
+        }
+    }
+
+    @decs.event_publisher
+    def test(event, context, **kwargs):
+        return {
+            'events': events
+        }
+
+    with Stubber(context.sns):
+        with pytest.raises(Invalid):
+            test(incoming_event, context.lambda_context)


### PR DESCRIPTION
## Description of the change

The new decorator will be used to publish event to SNS and eventaully EventBridge) events to be published via the handler response. For SNS events it adds the subject and the message_type attributes to allow event filtering by the listeners.

## Type of change
- [ ] Bug fix
- [x] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [x]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
