### PR TITLE
CP-4886: Add promition to release to pypi.cloudzero.com after master build

### DIFF
--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -16,4 +16,7 @@ blocks:
       jobs:
         - name: Upload
           commands:
-            - make upload
+            - make TWINE_USERNAME=${PYPI_USERNAME} TWINE_PASSWORD=${PYPI_PASSWORD} upload
+      secrets:
+        - name: PyPi Deployment
+        

--- a/.semaphore/release.yml
+++ b/.semaphore/release.yml
@@ -1,0 +1,19 @@
+version: v1.0
+name: Release
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Upload
+    task:
+      prologue:
+        commands:
+          - sem-version python 3.8
+          - checkout
+          - cache restore dev-requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements-dev.txt),requirements
+          - make init
+      jobs:
+        - name: Upload
+          commands:
+            - make upload

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -27,3 +27,17 @@ blocks:
         - name: Python Tests
           commands:
             - pytest
+
+promotions:
+  - name: Release
+    pipeline_file: release.yml
+    auto_promote_on:
+      - result: passed
+        branch:
+          - master
+  - name: Tag Release
+    pipeline_file: tag_release.yml
+    auto_promote_on:
+      - result: passed
+        branch:
+          - master

--- a/.semaphore/tag_release.yml
+++ b/.semaphore/tag_release.yml
@@ -1,0 +1,28 @@
+version: v1.0
+name: Tag Release
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu1804
+blocks:
+  - name: Release
+    task:
+      prologue:
+        commands:
+          - sudo chmod 600 ~/.ssh/semaphore_git_ssh
+          - sem-version python 3.8
+          - checkout
+          - cache restore dev-requirements-$SEMAPHORE_GIT_BRANCH-$(checksum requirements-dev.txt),requirements
+          - git config user.email "ops@cloudzero.com"
+          - git config user.name "Automated CZ Release"
+      jobs:
+        - name: Tag
+          commands:
+            - git tag -l | xargs git tag -d
+            - git fetch --tags
+            - CZ_VERSION=$(python -c "from pyfaaster import __version__; print(__version__.__version__)")
+            - git tag -a $CZ_VERSION -m "Automatic Semaphore Release for v$CZ_VERSION"
+            - git push origin $CZ_VERSION
+      secrets:
+        - name: Github SSH Key
+        - name: SSH Config

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         'Natural Language :: English',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
     ],
     # $ setup.py publish support.
     cmdclass={


### PR DESCRIPTION
## Description of the change

Add the semaphore yaml configurations to deploy the newer libraries to pypi.cloudzero.com after a successful build of the master branch.

## Type of change
- [ ] Bug fix
- [x] New feature

## Checklists

### Development
- [ ] All changed code has 80% unit test coverage
- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)

### Code review 
- [x]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.
