### PR TITLE
CP-5175 - allow config aware to take in generic functions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Description of the change
+
+> Did something awesome w/out a breaking change.
+
+## Type of change
+- [ ] Bug fix
+- [ ] New feature
+
+## Checklists
+
+### Development
+- [ ] All changed code has 80% unit test coverage
+- [ ] All changed code has been automatically (smoke test or otherwise) or manually verified in `alfa` (or with a cross namespace setup, e.g. developer namespace for this feature, pointing at shared `alfa` resources)
+
+### Code review 
+- [ ]  This pull request has a title that includes the ticket # and a short useful summary, e.g. `CP-4051: Create TEMPLATE Feature Repo`.

--- a/pyfaaster/__version__.py
+++ b/pyfaaster/__version__.py
@@ -3,4 +3,4 @@
 
 # PYFAASTER
 
-__version__ = '0.2.6'
+__version__ = '0.2.7'

--- a/pyfaaster/aws/handlers_decorators_v2.py
+++ b/pyfaaster/aws/handlers_decorators_v2.py
@@ -411,7 +411,7 @@ def configuration_aware(config_file, create=False):
         handler (func): a configuration aware lambda handler
     """
     def configuration_handler(handler):
-        def handler_wrapper(event, context, **kwargs):
+        def handler_wrapper(*args, **kwargs):
             config_bucket = os.environ['CONFIG']
             encrypt_key_arn = os.environ.get('ENCRYPT_KEY_ARN')
 
@@ -428,7 +428,8 @@ def configuration_aware(config_file, create=False):
                 'load': lambda: settings or {},
                 'save': functools.partial(conf.save, conn, config_bucket, config_file),
             }
-            return handler(event, context, configuration=configuration, **kwargs)
+            kwargs["configuration"] = configuration
+            return handler(*args, **kwargs)
 
         return handler_wrapper
 

--- a/tests/aws/test_handlers_decorators_v2.py
+++ b/tests/aws/test_handlers_decorators_v2.py
@@ -661,6 +661,7 @@ def test_catch_exceptions():
 @pytest.mark.unit
 def test_configuration_aware_lambda_handler(context):
     test_config = {"test": "configuration"}
+
     @decs.configuration_aware(CONFIG_FILE)
     def handler(event, context, configuration=None):
         assert configuration['load']() == test_config
@@ -673,6 +674,7 @@ def test_configuration_aware_lambda_handler(context):
 @pytest.mark.unit
 def test_configuration_aware_generic_function(context):
     test_config = {"test": "configuration"}
+
     @decs.configuration_aware(CONFIG_FILE)
     def handler(*args, **kwargs):
         assert kwargs['configuration']['load']() == test_config

--- a/tests/aws/test_handlers_decorators_v2.py
+++ b/tests/aws/test_handlers_decorators_v2.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2016-present, CloudZero, Inc. All rights reserved.
 # Licensed under the BSD-style license. See LICENSE file in the project root for full license information.
 from collections import namedtuple
+import mock
 
 import os
 import pytest
@@ -12,11 +13,12 @@ import pyfaaster.common.utils as utils
 from tests.aws.common import MockContext
 
 _CONFIG_BUCKET = 'example_config_bucket'
+CONFIG_FILE = 'example_config.json'
 
 
 @pytest.fixture(scope='function')
 def context(mocker):
-    context = namedtuple('context', ['os'])
+    context = namedtuple('context', ['os', 'mock_conf'])
 
     orig_env = os.environ.copy()
     os.environ['NAMESPACE'] = 'test-ns'
@@ -654,3 +656,28 @@ def test_catch_exceptions():
         throws_exception()
     except Exception:
         pytest.fail("The catch_exceptions decorator didn't do its job! You had one job ... one job!")
+
+
+@pytest.mark.unit
+def test_configuration_aware_lambda_handler(context):
+    test_config = {"test": "configuration"}
+    @decs.configuration_aware(CONFIG_FILE)
+    def handler(event, context, configuration=None):
+        assert configuration['load']() == test_config
+
+    with mock.patch("pyfaaster.aws.handlers_decorators_v2.conf") as mock_conf:
+        mock_conf.load.return_value = test_config
+        handler({}, None)
+
+
+@pytest.mark.unit
+def test_configuration_aware_generic_function(context):
+    test_config = {"test": "configuration"}
+    @decs.configuration_aware(CONFIG_FILE)
+    def handler(*args, **kwargs):
+        assert kwargs['configuration']['load']() == test_config
+
+    with mock.patch("pyfaaster.aws.handlers_decorators_v2.conf") as mock_conf:
+        mock_conf.load.return_value = test_config
+        handler()
+        handler('foo', 'bar', {'x': 'y'}, test_arg_1="something", test_arg_2=0)


### PR DESCRIPTION
This allows any generic function in the lambda environment to inject a config object, not just the lambda handler.
